### PR TITLE
Add a writeback cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,56 @@ d.get(random_string(8), None)
 # 53.1 µs ± 4.42 µs per loop (mean ± std. dev. of 10 runs, 20000 loops each)
 ```
 
+## Writeback Cache
+
+Inspired by the writeback cache of [shelve](https://docs.python.org/3/library/shelve.html), litedict optionally implements a writeback cache (defaults to False). This enables mutating mutable objects by keeping a cache of all entries accessed and writing them back upon `d.close()` or `d.sync()`. 
+
+Consider the following examples:
+
+This will *not* save the values mutated:
+
+```python
+d = SQLDict("example.db",writeback=False)
+d['mylist'] = []
+d['mylist'].append('myitem')
+print(d['mylist']) # output: []
+```
+
+This *will* mutate the item and then save it upon `d.close()` to be read again
+
+```python
+d = SQLDict("example.db",writeback=True)
+d['mylist'] = []
+d['mylist'].append('myitem')
+print(d['mylist']) # output: ['myitem']
+
+d.close()
+
+d = SQLDict("example.db",writeback=True)
+print(d['mylist']) # output: ['myitem']
+```
+
+Finally, to achieve the save thing without `writeback=True` you could do the following:
+
+```python
+d = SQLDict("example.db",writeback=False)
+d['mylist'] = []
+
+mylist = d['mylist']
+mylist.append('myitem')
+
+d['mylist'] =  mylist # This saves the item
+print(d['mylist']) # output: ['myitem']
+
+# Good practice is to call d.close() but it is commented out
+# to demonstrate that you don't even need it since it is written above
+
+d2 = SQLDict("example.db",writeback=True)
+print(d2['mylist']) # output: ['myitem']
+```
+
+
+
 ## Changelog
 
 * 0.3

--- a/tests.ipynb
+++ b/tests.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "restricted-immigration",
    "metadata": {},
    "outputs": [],
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "weird-depth",
    "metadata": {},
    "outputs": [],
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "aerial-float",
    "metadata": {},
    "outputs": [],
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "secure-platinum",
    "metadata": {},
    "outputs": [],
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "sixth-consistency",
    "metadata": {},
    "outputs": [],
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "north-equipment",
    "metadata": {},
    "outputs": [],
@@ -118,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "minute-distinction",
    "metadata": {},
    "outputs": [],
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "aquatic-receiver",
    "metadata": {},
    "outputs": [],
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "4f5619c0",
    "metadata": {},
    "outputs": [
@@ -158,11 +158,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "key_testx_3 \"barasdfoo\"\n",
+      "key_testx_3 barasdfoo\n",
       "key_test_1 1\n",
       "key_test_2 2\n",
-      "asd \"efg\"\n",
-      "foo \"bar\"\n"
+      "asd efg\n",
+      "foo bar\n"
      ]
     }
    ],
@@ -181,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "95df7552",
    "metadata": {},
    "outputs": [],
@@ -237,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "optional-settle",
    "metadata": {},
    "outputs": [],
@@ -258,7 +258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "devoted-cruise",
    "metadata": {},
    "outputs": [],
@@ -280,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "sacred-track",
    "metadata": {},
    "outputs": [],
@@ -294,17 +294,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "dense-ozone",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "152"
+       "67"
       ]
      },
-     "execution_count": null,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -315,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "sacred-tennis",
    "metadata": {},
    "outputs": [
@@ -323,7 +323,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "36.8 µs ± 928 ns per loop (mean ± std. dev. of 10 runs, 20,000 loops each)\n"
+      "44.2 µs ± 431 ns per loop (mean ± std. dev. of 10 runs, 20,000 loops each)\n"
      ]
     }
    ],
@@ -345,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "imported-university",
    "metadata": {},
    "outputs": [],
@@ -359,7 +359,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "tutorial-trauma",
    "metadata": {},
    "outputs": [
@@ -369,7 +369,7 @@
        "3"
       ]
      },
-     "execution_count": null,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -380,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "bulgarian-colombia",
    "metadata": {},
    "outputs": [
@@ -388,7 +388,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "35 µs ± 941 ns per loop (mean ± std. dev. of 10 runs, 20,000 loops each)\n"
+      "42.4 µs ± 750 ns per loop (mean ± std. dev. of 10 runs, 20,000 loops each)\n"
      ]
     }
    ],
@@ -410,7 +410,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "frank-stable",
    "metadata": {},
    "outputs": [],
@@ -424,7 +424,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "wooden-enlargement",
    "metadata": {},
    "outputs": [
@@ -434,7 +434,7 @@
        "3"
       ]
      },
-     "execution_count": null,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -445,7 +445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "after-essex",
    "metadata": {},
    "outputs": [
@@ -453,7 +453,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "35.9 µs ± 707 ns per loop (mean ± std. dev. of 10 runs, 20,000 loops each)\n"
+      "44.1 µs ± 949 ns per loop (mean ± std. dev. of 10 runs, 20,000 loops each)\n"
      ]
     }
    ],
@@ -475,7 +475,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "dressed-investor",
    "metadata": {},
    "outputs": [],
@@ -489,7 +489,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "id": "sustained-aviation",
    "metadata": {},
    "outputs": [
@@ -499,7 +499,7 @@
        "3"
       ]
      },
-     "execution_count": null,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -510,7 +510,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "technological-filling",
    "metadata": {},
    "outputs": [],
@@ -531,7 +531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "direct-accent",
    "metadata": {},
    "outputs": [
@@ -539,7 +539,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "20.8 µs ± 574 ns per loop (mean ± std. dev. of 10 runs, 20,000 loops each)\n"
+      "29.3 µs ± 635 ns per loop (mean ± std. dev. of 10 runs, 20,000 loops each)\n"
      ]
     }
    ],
@@ -561,7 +561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "id": "ready-palestine",
    "metadata": {},
    "outputs": [],
@@ -571,7 +571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "beginning-survey",
    "metadata": {},
    "outputs": [
@@ -581,7 +581,7 @@
        "3"
       ]
      },
-     "execution_count": null,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -592,7 +592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "id": "civic-preservation",
    "metadata": {},
    "outputs": [
@@ -600,7 +600,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "26 µs ± 574 ns per loop (mean ± std. dev. of 10 runs, 20,000 loops each)\n"
+      "30.6 µs ± 1.03 µs per loop (mean ± std. dev. of 10 runs, 20,000 loops each)\n"
      ]
     }
    ],
@@ -611,9 +611,160 @@
     "\n",
     "d.get(random_string(8), None)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c22f702-66fa-4d71-9fd0-a6e5fbf98464",
+   "metadata": {},
+   "source": [
+    "## Writeback Cache"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28808cf9-04f3-4954-a8b5-1ff941e4b4a1",
+   "metadata": {},
+   "source": [
+    "### Missing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "54179289-7dcb-42a9-959f-f0bda8241ef4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d = SQLDict(\":memory:\",writeback=False)\n",
+    "mylist = d['test'] = []\n",
+    "\n",
+    "assert not d['test'] is mylist, \"using writeback when not set\"\n",
+    "assert mylist == d['test'], \"equality should still pass\"\n",
+    "\n",
+    "mylist.append(1)\n",
+    "assert mylist != d['test'], \"Should not be equal\"\n",
+    "d.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6719b05a-7b76-4a82-a859-51c5518085fa",
+   "metadata": {},
+   "source": [
+    "### With writeback"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "ec995b2e-eaed-46ef-bb84-b3d3307e15c2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "d2['test'] = [1] d['test'] = [1]\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    d = SQLDict(\"__tmp.db\",writeback=True)\n",
+    "    mylist = d['test'] = []\n",
+    "\n",
+    "    assert mylist is d['test'], \"should be the same object\"\n",
+    "    assert mylist == d['test'], \"equality should pass\"\n",
+    "\n",
+    "    mylist.append(1)\n",
+    "    assert mylist is d['test'], \"should be the same object\"\n",
+    "    assert mylist == d['test'], \"Should still be equal\"\n",
+    "    \n",
+    "    d2 =  SQLDict(\"__tmp.db\",writeback=True)\n",
+    "    \n",
+    "    # This should fail since there was no sync\n",
+    "    assert d2['test'] != d['test']\n",
+    "    \n",
+    "    d.sync()\n",
+    "    \n",
+    "    d2 =  SQLDict(\"__tmp.db\",writeback=True)\n",
+    "    # Now this should pass\n",
+    "    print(f\"{d2['test'] = } {d['test'] = }\")\n",
+    "    assert d2['test'] == d['test']\n",
+    "    \n",
+    "finally:\n",
+    "    pass#os.unlink(\"__tmp.db\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4c4933b-29bf-4643-88c7-758a7574435e",
+   "metadata": {},
+   "source": [
+    "These are a few more methods where the code was modified for writeback"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "0ff01b18-c411-485f-9a05-6d63587aff8a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for writeback in [True,False]:\n",
+    "    d = SQLDict(\":memory:\",writeback=False)\n",
+    "    mylist = d['test'] = ['this','is','a','test']\n",
+    "\n",
+    "    assert d.glob('te*') == [['this', 'is', 'a', 'test']]\n",
+    "    \n",
+    "    del d['test']\n",
+    "    assert 'test' not in d\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9351295a-89a5-4cfe-95ed-177624b2e9db",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e4f6032-d023-4058-9843-fe0c00b58dde",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1091aae-c1c9-4826-ba99-cf546b7275ec",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
This adds an optional writeback cache similar to the one that is in the standard library's shelve module. The writeback cache allows for mutable items to behave as expected at the cost of having to write all items to disk upon close() or sync()